### PR TITLE
Update FFI bindings to latest C library version. Add error handling struct

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,5 +1,5 @@
 extern crate gcc;
 
 fn main() {
-	gcc::compile_library("libws281x.a", &["c/mailbox.c", "c/ws2811.c", "c/pwm.c", "c/dma.c", "c/rpihw.c"]);
+	gcc::compile_library("libws281x.a", &["c/mailbox.c", "c/ws2811.c", "c/pwm.c", "c/dma.c", "c/rpihw.c", "c/pcm.c"]);
 }

--- a/src/channel/builder.rs
+++ b/src/channel/builder.rs
@@ -13,7 +13,7 @@
 //  0. You just DO WHAT THE FUCK YOU WANT TO.
 
 use std::{mem, ptr};
-use libc::c_int;
+use libc::{c_int, uint8_t};
 use {ffi, Strip};
 use super::Channel;
 
@@ -41,8 +41,8 @@ impl Builder {
 		self
 	}
 
-	pub fn brightness(&mut self, value: i32) -> &mut Self {
-		self.0.brightness = value as c_int;
+	pub fn brightness(&mut self, value: u8) -> &mut Self {
+		self.0.brightness = value as uint8_t;
 		self
 	}
 

--- a/src/channel/mutable.rs
+++ b/src/channel/mutable.rs
@@ -1,6 +1,6 @@
 use std::ops::Deref;
 use std::slice;
-use libc::c_int;
+use libc::{c_int, uint8_t};
 use {ffi, Led, Strip};
 use super::ChannelRef;
 
@@ -24,9 +24,9 @@ impl<'a> Ref<'a> {
 		}
 	}
 
-	pub fn set_brightness(&mut self, value: i32) {
+	pub fn set_brightness(&mut self, value: u8) {
 		unsafe {
-			(*self.0).brightness = value as c_int;
+			(*self.0).brightness = value as uint8_t;
 		}
 	}
 

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -12,7 +12,7 @@
 //
 //  0. You just DO WHAT THE FUCK YOU WANT TO.
 
-use libc::{c_void, c_char, c_int, uint32_t};
+use libc::{c_void, c_char, c_int, uint32_t, uint8_t, uint64_t};
 
 pub const RPI_PWM_CHANNELS: usize = 2;
 
@@ -137,14 +137,19 @@ pub struct ws2811_channel_t {
 	pub gpionum: c_int,
 	pub invert: c_int,
 	pub count: c_int,
-	pub brightness: c_int,
 	pub strip_type: c_int,
 	pub leds: *mut ws2811_led_t,
+	pub brightness: uint8_t,
+	pub wshift: uint8_t,
+	pub rshift: uint8_t,
+	pub gshift: uint8_t,
+	pub bshift: uint8_t,
 }
 
 #[derive(Debug)]
 #[repr(C)]
 pub struct ws2811_t {
+	pub render_wait_until: uint64_t,
 	pub device: *mut ws2811_device_t,
 	pub rpi_hw: *const rpi_hw_t,
 	pub freq: uint32_t,

--- a/src/handle/builder.rs
+++ b/src/handle/builder.rs
@@ -16,6 +16,8 @@ use std::{mem, ptr};
 use libc::{c_int, uint32_t};
 use {ffi, Handle, Channel};
 
+use handle::handle_error::HandleCreationError;
+
 pub struct Builder(ffi::ws2811_t);
 
 impl Builder {
@@ -46,7 +48,7 @@ impl Builder {
 		self
 	}
 
-	pub fn build(&mut self) -> Result<Handle, ()> {
+	pub fn build(&mut self) -> Result<Handle, HandleCreationError> {
 		unsafe {
 			Handle::new(ptr::read(&self.0))
 		}

--- a/src/handle/handle.rs
+++ b/src/handle/handle.rs
@@ -17,13 +17,16 @@ use {ffi, ChannelRef, ChannelMut};
 /// Handle to a WS281X device.
 pub struct Handle(ffi::ws2811_t);
 
+use handle::handle_error::HandleCreationError;
+
 impl Handle {
-	pub unsafe fn new(mut value: ffi::ws2811_t) -> Result<Self, ()> {
-		if ffi::ws2811_init(&mut value) >= 0 {
+	pub unsafe fn new(mut value: ffi::ws2811_t) -> Result<Self, HandleCreationError> {
+		let status = ffi::ws2811_init(&mut value);
+		if status >= 0 {
 			Ok(Handle(value))
 		}
 		else {
-			Err(())
+			Err(HandleCreationError{code: status})
 		}
 	}
 

--- a/src/handle/handle_error.rs
+++ b/src/handle/handle_error.rs
@@ -1,0 +1,35 @@
+use std::error::Error;
+use std::fmt;
+
+#[derive(Debug)]
+pub struct HandleCreationError {
+	pub code: i32
+}
+
+impl Error for HandleCreationError {
+	fn description(&self) -> &str {
+		match self.code {
+			-1 => "Generic failure",
+			-2 => "Out of memory",
+			-3 => "Hardware revision is not supported",
+			-4 => "Memory lock failed",
+			-5 => "mmap() failed",
+			-6 => "Unable to map registers into userspace",
+			-7 => "Unable to initialize GPIO",
+			-8 => "Unable to initialize PWM",
+			-9 => "Failed to create mailbox device",
+			-10 => "DMA error",
+			-11 => "Selected GPIO not possible",
+			-12 => "Unable to initialize PCM",
+			-13 => "Unable to initialize SPI",
+			-14 => "SPI transfer error",
+			_ => "unrecognised error"
+		}
+	}
+}
+
+impl fmt::Display for HandleCreationError {
+	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+		write!(f, "Handle creation failed, error code: {}. {}", self.code, self.description())
+	}
+}

--- a/src/handle/mod.rs
+++ b/src/handle/mod.rs
@@ -12,6 +12,9 @@
 //
 //  0. You just DO WHAT THE FUCK YOU WANT TO.
 
+mod handle_error;
+pub use self::handle_error::HandleCreationError;
+
 mod handle;
 pub use self::handle::Handle;
 


### PR DESCRIPTION
#1 was caused by the version of the C library used by this crate being outdated and not supporting the raspberry pi zero w. This PR should fix that issue.

I also added a `HandleError` result type to make debugging issues with the library easier.