### PR TITLE
Update to latest submodule version and fix compiler warnings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,4 +16,4 @@ links = "ws281x"
 libc = "0.2"
 
 [build-dependencies]
-gcc = "0.3"
+cc = "1.0"

--- a/build.rs
+++ b/build.rs
@@ -1,5 +1,12 @@
-extern crate gcc;
+extern crate cc;
 
 fn main() {
-	gcc::compile_library("libws281x.a", &["c/mailbox.c", "c/ws2811.c", "c/pcm.c", "c/pwm.c", "c/dma.c", "c/rpihw.c"]);
+	cc::Build::new()
+            .file("c/mailbox.c")
+            .file("c/ws2811.c")
+            .file("c/pwm.c")
+            .file("c/pcm.c")
+            .file("c/dma.c")
+            .file("c/rpihw.c")
+            .compile("libws281x.a");
 }

--- a/build.rs
+++ b/build.rs
@@ -1,5 +1,5 @@
 extern crate gcc;
 
 fn main() {
-	gcc::compile_library("libws281x.a", &["c/mailbox.c", "c/ws2811.c", "c/pwm.c", "c/dma.c", "c/rpihw.c"]);
+	gcc::compile_library("libws281x.a", &["c/mailbox.c", "c/ws2811.c", "c/pcm.c", "c/pwm.c", "c/dma.c", "c/rpihw.c"]);
 }

--- a/src/channel/builder.rs
+++ b/src/channel/builder.rs
@@ -41,8 +41,8 @@ impl Builder {
 		self
 	}
 
-	pub fn brightness(&mut self, value: i32) -> &mut Self {
-		self.0.brightness = value as c_int;
+	pub fn brightness(&mut self, value: u8) -> &mut Self {
+		self.0.brightness = value;
 		self
 	}
 

--- a/src/channel/mutable.rs
+++ b/src/channel/mutable.rs
@@ -24,9 +24,9 @@ impl<'a> Ref<'a> {
 		}
 	}
 
-	pub fn set_brightness(&mut self, value: i32) {
+	pub fn set_brightness(&mut self, value: u8) {
 		unsafe {
-			(*self.0).brightness = value as c_int;
+			(*self.0).brightness = value;
 		}
 	}
 

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -12,68 +12,68 @@
 //
 //  0. You just DO WHAT THE FUCK YOU WANT TO.
 
-use libc::{c_void, c_char, c_int, uint32_t};
+use libc::{c_void, c_char, c_int};
 
 pub const RPI_PWM_CHANNELS: usize = 2;
 
-pub const RPI_PWM_CTL_MSEN2: uint32_t = 1 << 15;
-pub const RPI_PWM_CTL_USEF2: uint32_t = 1 << 13;
-pub const RPI_PWM_CTL_POLA2: uint32_t = 1 << 12;
-pub const RPI_PWM_CTL_SBIT2: uint32_t = 1 << 11;
-pub const RPI_PWM_CTL_RPTL2: uint32_t = 1 << 10;
-pub const RPI_PWM_CTL_MODE2: uint32_t = 1 << 9;
-pub const RPI_PWM_CTL_PWEN2: uint32_t = 1 << 8;
-pub const RPI_PWM_CTL_MSEN1: uint32_t = 1 << 7;
-pub const RPI_PWM_CTL_CLRF1: uint32_t = 1 << 6;
-pub const RPI_PWM_CTL_USEF1: uint32_t = 1 << 5;
-pub const RPI_PWM_CTL_POLA1: uint32_t = 1 << 4;
-pub const RPI_PWM_CTL_SBIT1: uint32_t = 1 << 3;
-pub const RPI_PWM_CTL_RPTL1: uint32_t = 1 << 2;
-pub const RPI_PWM_CTL_MODE1: uint32_t = 1 << 1;
-pub const RPI_PWM_CTL_PWEN1: uint32_t = 1 << 0;
+pub const RPI_PWM_CTL_MSEN2: u32 = 1 << 15;
+pub const RPI_PWM_CTL_USEF2: u32 = 1 << 13;
+pub const RPI_PWM_CTL_POLA2: u32 = 1 << 12;
+pub const RPI_PWM_CTL_SBIT2: u32 = 1 << 11;
+pub const RPI_PWM_CTL_RPTL2: u32 = 1 << 10;
+pub const RPI_PWM_CTL_MODE2: u32 = 1 << 9;
+pub const RPI_PWM_CTL_PWEN2: u32 = 1 << 8;
+pub const RPI_PWM_CTL_MSEN1: u32 = 1 << 7;
+pub const RPI_PWM_CTL_CLRF1: u32 = 1 << 6;
+pub const RPI_PWM_CTL_USEF1: u32 = 1 << 5;
+pub const RPI_PWM_CTL_POLA1: u32 = 1 << 4;
+pub const RPI_PWM_CTL_SBIT1: u32 = 1 << 3;
+pub const RPI_PWM_CTL_RPTL1: u32 = 1 << 2;
+pub const RPI_PWM_CTL_MODE1: u32 = 1 << 1;
+pub const RPI_PWM_CTL_PWEN1: u32 = 1 << 0;
 
-pub const RPI_PWM_STA_STA4:  uint32_t = 1 << 12;
-pub const RPI_PWM_STA_STA3:  uint32_t = 1 << 11;
-pub const RPI_PWM_STA_STA2:  uint32_t = 1 << 10;
-pub const RPI_PWM_STA_STA1:  uint32_t = 1 << 9;
-pub const RPI_PWM_STA_BERR:  uint32_t = 1 << 8;
-pub const RPI_PWM_STA_GAP04: uint32_t = 1 << 7;
-pub const RPI_PWM_STA_GAP03: uint32_t = 1 << 6;
-pub const RPI_PWM_STA_GAP02: uint32_t = 1 << 5;
-pub const RPI_PWM_STA_GAP01: uint32_t = 1 << 4;
-pub const RPI_PWM_STA_RERR1: uint32_t = 1 << 3;
-pub const RPI_PWM_STA_WERR1: uint32_t = 1 << 2;
-pub const RPI_PWM_STA_EMPT1: uint32_t = 1 << 1;
-pub const RPI_PWM_STA_FULL1: uint32_t = 1 << 0;
+pub const RPI_PWM_STA_STA4:  u32 = 1 << 12;
+pub const RPI_PWM_STA_STA3:  u32 = 1 << 11;
+pub const RPI_PWM_STA_STA2:  u32 = 1 << 10;
+pub const RPI_PWM_STA_STA1:  u32 = 1 << 9;
+pub const RPI_PWM_STA_BERR:  u32 = 1 << 8;
+pub const RPI_PWM_STA_GAP04: u32 = 1 << 7;
+pub const RPI_PWM_STA_GAP03: u32 = 1 << 6;
+pub const RPI_PWM_STA_GAP02: u32 = 1 << 5;
+pub const RPI_PWM_STA_GAP01: u32 = 1 << 4;
+pub const RPI_PWM_STA_RERR1: u32 = 1 << 3;
+pub const RPI_PWM_STA_WERR1: u32 = 1 << 2;
+pub const RPI_PWM_STA_EMPT1: u32 = 1 << 1;
+pub const RPI_PWM_STA_FULL1: u32 = 1 << 0;
 
-pub const RPI_PWM_DMAC_ENAB: uint32_t = 1 << 31;
+pub const RPI_PWM_DMAC_ENAB: u32 = 1 << 31;
 
 #[inline(always)]
-pub unsafe fn RPI_PWM_DMAC_PANIC(val: uint32_t) -> uint32_t {
+pub unsafe fn RPI_PWM_DMAC_PANIC(val: u32) -> u32 {
 	(val & 0xff) << 8
 }
 
-pub unsafe fn RPI_PWM_DMAC_DREQ(val: uint32_t) -> uint32_t {
+pub unsafe fn RPI_PWM_DMAC_DREQ(val: u32) -> u32 {
 	val & 0xff
 }
 
 #[derive(Debug)]
 #[repr(C)]
 pub struct pwm_t {
-	pub ctl: uint32_t,
-	pub sta: uint32_t,
-	pub dmac: uint32_t,
-	pub resvd_0x0c: uint32_t,
-	pub rng1: uint32_t,
-	pub dat1: uint32_t,
-	pub fif1: uint32_t,
-	pub resvd_0x1c: uint32_t,
-	pub rng2: uint32_t,
-	pub dat2: uint32_t,
+	pub ctl: u32,
+	pub sta: u32,
+	pub dmac: u32,
+	pub resvd_0x0c: u32,
+	pub rng1: u32,
+	pub dat1: u32,
+	pub fif1: u32,
+	pub resvd_0x1c: u32,
+	pub rng2: u32,
+	pub dat2: u32,
 }
 
-pub const PWM_OFFSET:      uint32_t = 0x0020c000;
-pub const PWM_PERIPH_PHYS: uint32_t = 0x7e20c000;
+pub const PWM_OFFSET:      u32 = 0x0020c000;
+pub const PWM_PERIPH_PHYS: u32 = 0x7e20c000;
 
 #[derive(Debug)]
 #[repr(C)]
@@ -89,23 +89,23 @@ pub struct pwm_pin_tables_t {
 	pins: *const pwm_pin_table_t,
 }
 
-pub const RPI_HWVER_TYPE_UNKNOWN: uint32_t = 0;
-pub const RPI_HWVER_TYPE_PI1:     uint32_t = 1;
-pub const RPI_HWVER_TYPE_PI2:     uint32_t = 2;
+pub const RPI_HWVER_TYPE_UNKNOWN: u32 = 0;
+pub const RPI_HWVER_TYPE_PI1:     u32 = 1;
+pub const RPI_HWVER_TYPE_PI2:     u32 = 2;
 
 #[derive(Debug)]
 #[repr(C)]
 pub struct rpi_hw_t {
-	pub type_: uint32_t,
-	pub hwver: uint32_t,
-	pub periph_base: uint32_t,
-	pub videocore_base: uint32_t,
+	pub type_: u32,
+	pub hwver: u32,
+	pub periph_base: u32,
+	pub videocore_base: u32,
 	pub desc: *mut c_char,
 }
 
 // Can go as low as 400000
-pub const WS2811_TARGET_FREQ: uint32_t = 800000;
-pub const SK6812_SHIFT_WMASK: uint32_t = 0xf0000000;
+pub const WS2811_TARGET_FREQ: u32 = 800000;
+pub const SK6812_SHIFT_WMASK: u32 = 0xf0000000;
 
 // 4 color R, G, B and W ordering
 pub const SK6812_STRIP_RGBW:  c_int = 0x18100800;
@@ -129,7 +129,7 @@ pub const SK6812_STRIP:  c_int = WS2811_STRIP_GRB;
 pub const SK6812W_STRIP: c_int = SK6812_STRIP_GRBW;
 
 pub type ws2811_device_t = c_void;
-pub type ws2811_led_t = uint32_t;
+pub type ws2811_led_t = u32;
 
 #[derive(Debug)]
 #[repr(C)]
@@ -137,17 +137,22 @@ pub struct ws2811_channel_t {
 	pub gpionum: c_int,
 	pub invert: c_int,
 	pub count: c_int,
-	pub brightness: c_int,
 	pub strip_type: c_int,
 	pub leds: *mut ws2811_led_t,
+	pub brightness: u8,
+	pub wshift: u8,
+	pub gshift: u8,
+	pub bshift: u8,
+	pub gamma: *mut u8,
 }
 
 #[derive(Debug)]
 #[repr(C)]
 pub struct ws2811_t {
+	pub render_wait_time: u64,
 	pub device: *mut ws2811_device_t,
 	pub rpi_hw: *const rpi_hw_t,
-	pub freq: uint32_t,
+	pub freq: u32,
 	pub dmanum: c_int,
 	pub channel: [ws2811_channel_t; RPI_PWM_CHANNELS],
 }

--- a/src/handle/builder.rs
+++ b/src/handle/builder.rs
@@ -13,7 +13,7 @@
 //  0. You just DO WHAT THE FUCK YOU WANT TO.
 
 use std::{mem, ptr};
-use libc::{c_int, uint32_t};
+use libc::{c_int};
 use {ffi, Handle, Channel};
 
 pub struct Builder(ffi::ws2811_t);
@@ -29,7 +29,7 @@ impl Builder {
 	}
 
 	pub fn frequency(&mut self, value: u32) -> &mut Self {
-		self.0.freq = value as uint32_t;
+		self.0.freq = value as u32;
 		self
 	}
 


### PR DESCRIPTION
Note: I only realized after patching this locally that there's already another PR with very similar contents. 

I'm still creating a PR, since this version does not contain any changes beyond those necessary to compile without warnings against the newest version fo the C library, so there might be less objections to merging it.

